### PR TITLE
Fix profiling of early hooks

### DIFF
--- a/features/profile-hook.feature
+++ b/features/profile-hook.feature
@@ -1,5 +1,13 @@
 Feature: Profile a specific hook
 
+  Scenario: Profile a hook before the template is loaded
+    Given a WP install
+
+    When I run `wp profile --hook=plugins_loaded --fields=callback`
+    Then STDOUT should be a table containing rows:
+      | callback          |
+    And STDERR should be empty
+
   Scenario: Profile a hook without any callbacks
     Given a WP install
 


### PR DESCRIPTION
When we throw an Exception to bail out of the call, this means the rest
of the bootstrap code hasn't executed, and important things aren't set
up. Instead, we need to summarize early.
