### PR TITLE
Put names to the intermediate stages

### DIFF
--- a/features/profile-stage.feature
+++ b/features/profile-stage.feature
@@ -15,98 +15,98 @@ Feature: Profile the template render stage
 
     When I run `wp profile stage bootstrap --fields=hook`
     Then STDOUT should be a table containing rows:
-      | hook              |
-      |                   |
-      | muplugins_loaded  |
-      |                   |
-      | plugins_loaded    |
-      |                   |
-      | setup_theme       |
-      |                   |
-      | after_setup_theme |
-      |                   |
-      | init              |
-      |                   |
-      | wp_loaded         |
-      |                   |
-      | total             |
+      | hook                     |
+      | muplugins_loaded:before  |
+      | muplugins_loaded         |
+      | plugins_loaded:before    |
+      | plugins_loaded           |
+      | setup_theme:before       |
+      | setup_theme              |
+      | after_setup_theme:before |
+      | after_setup_theme        |
+      | init:before              |
+      | init                     |
+      | wp_loaded:before         |
+      | wp_loaded                |
+      | wp_loaded:after          |
+      | total                    |
 
     When I run `wp profile stage main_query --fields=hook`
     Then STDOUT should be a table containing rows:
-      | hook              |
-      |                   |
-      | parse_request     |
-      |                   |
-      | send_headers      |
-      |                   |
-      | pre_get_posts     |
-      |                   |
-      | the_posts         |
-      |                   |
-      | wp                |
-      |                   |
-      | total             |
+      | hook                     |
+      | parse_request:before     |
+      | parse_request            |
+      | send_headers:before      |
+      | send_headers             |
+      | pre_get_posts:before     |
+      | pre_get_posts            |
+      | the_posts:before         |
+      | the_posts                |
+      | wp:before                |
+      | wp                       |
+      | wp:after                 |
+      | total                    |
 
     When I run `wp profile stage template --fields=hook`
     Then STDOUT should be a table containing rows:
-      | hook              |
-      |                   |
-      | template_redirect |
-      |                   |
-      | template_include  |
-      |                   |
-      | wp_head           |
-      |                   |
-      | loop_start        |
-      |                   |
-      | loop_end          |
-      |                   |
-      | wp_footer         |
-      |                   |
-      | total             |
+      | hook                     |
+      | template_redirect:before |
+      | template_redirect        |
+      | template_include:before  |
+      | template_include         |
+      | wp_head:before           |
+      | wp_head                  |
+      | loop_start:before        |
+      | loop_start               |
+      | loop_end:before          |
+      | loop_end                 |
+      | wp_footer:before         |
+      | wp_footer                |
+      | wp_footer:after          |
+      | total                    |
 
   Scenario: Use --all flag to profile all stages
     Given a WP install
 
     When I run `wp profile stage --all --fields=hook`
     Then STDOUT should be a table containing rows:
-      | hook              |
-      |                   |
-      | muplugins_loaded  |
-      |                   |
-      | plugins_loaded    |
-      |                   |
-      | setup_theme       |
-      |                   |
-      | after_setup_theme |
-      |                   |
-      | init              |
-      |                   |
-      | wp_loaded         |
-      |                   |
-      | parse_request     |
-      |                   |
-      | send_headers      |
-      |                   |
-      | pre_get_posts     |
-      |                   |
-      | the_posts         |
-      |                   |
-      | wp                |
-      |                   |
-      | template_redirect |
-      |                   |
-      | template_include  |
-      |                   |
-      | wp_head           |
-      |                   |
-      | loop_start        |
-      |                   |
-      | loop_end          |
-      |                   |
-      | wp_footer         |
-      |                   |
-      | total             |
+      | hook                     |
+      | muplugins_loaded:before  |
+      | muplugins_loaded         |
+      | plugins_loaded:before    |
+      | plugins_loaded           |
+      | setup_theme:before       |
+      | setup_theme              |
+      | after_setup_theme:before |
+      | after_setup_theme        |
+      | init:before              |
+      | init                     |
+      | wp_loaded:before         |
+      | wp_loaded                |
+      | parse_request:before     |
+      | parse_request            |
+      | send_headers:before      |
+      | send_headers             |
+      | pre_get_posts:before     |
+      | pre_get_posts            |
+      | the_posts:before         |
+      | the_posts                |
+      | wp:before                |
+      | wp                       |
+      | template_redirect:before |
+      | template_redirect        |
+      | template_include:before  |
+      | template_include         |
+      | wp_head:before           |
+      | wp_head                  |
+      | loop_start:before        |
+      | loop_start               |
+      | loop_end:before          |
+      | loop_end                 |
+      | wp_footer:before         |
+      | wp_footer                |
+      | wp_footer:after          |
+      | total                    |
 
   Scenario: Invalid stage specified
     Given a WP install


### PR DESCRIPTION
For the most part, it's `<hook>:before`, except when it's the last hook
in the sequence.

See https://github.com/runcommand/sparks/issues/15
