### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "runcommand/profile",
     "description": "Quickly identify what's slow with WordPress.",
+    "type": "wp-cli-package",
     "homepage": "https://runcommand.io/wp/profile/",
     "license": "GPL-2.0",
     "version": "0.3.0-alpha",


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
