### PR TITLE
Drop version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "type": "wp-cli-package",
     "homepage": "https://runcommand.io/wp/profile/",
     "license": "MIT",
-    "version": "0.3.0-beta",
     "authors": [],
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
WP-CLI doesn't like it right now.

See https://github.com/wp-cli/wp-cli/issues/3518