### PR TITLE
Drop execution time from cache test

### DIFF
--- a/features/profile-eval.feature
+++ b/features/profile-eval.feature
@@ -26,12 +26,12 @@ Feature: Profile arbitary code execution
   Scenario: Profile calls to the object cache
     Given a WP install
 
-    When I run `wp profile eval 'wp_cache_get( "foo" );' --fields=time,cache_hits,cache_misses`
+    When I run `wp profile eval 'wp_cache_get( "foo" );' --fields=cache_hits,cache_misses`
     Then STDOUT should be a table containing rows:
-      | time     | cache_hits    | cache_misses |
-      | 0s       | 0             | 1            |
+      | cache_hits    | cache_misses |
+      | 0             | 1            |
 
-    When I run `wp profile eval 'wp_cache_set( "foo", "bar" ); wp_cache_get( "foo" ); wp_cache_get( "foo" );' --fields=time,cache_hits,cache_misses`
+    When I run `wp profile eval 'wp_cache_set( "foo", "bar" ); wp_cache_get( "foo" ); wp_cache_get( "foo" );' --fields=cache_hits,cache_misses`
     Then STDOUT should be a table containing rows:
-      | time     | cache_hits    | cache_misses |
-      | 0s       | 2             | 0            |
+      | cache_hits    | cache_misses |
+      | 2             | 0            |


### PR DESCRIPTION
Sometimes this rounds to a non-zero value, which causes tests to fail