### PR TITLE
Fix using --format other than table

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -4,16 +4,17 @@ namespace WP_CLI\Profile;
 
 class Logger {
 
-	public $time          = 0;
-	public $query_count   = 0;
-	public $query_time    = 0;
-	public $cache_hits    = 0;
-	public $cache_misses  = 0;
-	public $cache_ratio   = null;
-	public $hook_count    = 0;
-	public $hook_time     = 0;
-	public $request_count = 0;
-	public $request_time  = 0;
+	public $time           = 0;
+	public $query_count    = 0;
+	public $query_time     = 0;
+	public $cache_hits     = 0;
+	public $cache_misses   = 0;
+	public $cache_ratio    = null;
+	public $hook_count     = 0;
+	public $hook_time      = 0;
+	public $request_count  = 0;
+	public $request_time   = 0;
+	public $callback_count = 0;
 
 	private $start_time         = null;
 	private $query_offset       = null;


### PR DESCRIPTION
As pointed out on issue #152 the `--format` option is not doing so well when using values other than `table`.
Also on that issue, @swang-va commented (https://github.com/wp-cli/profile-command/issues/152#issuecomment-489212586) about a possible solution that seems to fix the issue.

Fixes #152 