### PR TITLE
Remove default value from $include_total

### DIFF
--- a/features/profile-hook.feature
+++ b/features/profile-hook.feature
@@ -46,7 +46,7 @@ Feature: Profile a specific hook
   Scenario: Profile a hook without any callbacks
     Given a WP install
 
-    When I run `wp profile hook setup_theme --fields=callback`
+    When I run `wp profile hook get_search_form --fields=callback`
     Then STDOUT should be a table containing rows:
       | callback          |
       | total (0)         |

--- a/features/profile-stage.feature
+++ b/features/profile-stage.feature
@@ -29,7 +29,6 @@ Feature: Profile the template render stage
       | wp_loaded:before         |
       | wp_loaded                |
       | wp_loaded:after          |
-      | total (13)               |
 
     When I run `wp profile stage main_query --fields=hook`
     Then STDOUT should be a table containing rows:
@@ -45,7 +44,6 @@ Feature: Profile the template render stage
       | wp:before                |
       | wp                       |
       | wp:after                 |
-      | total (11)               |
 
     When I run `wp profile stage template --fields=hook`
     Then STDOUT should be a table containing rows:
@@ -63,7 +61,6 @@ Feature: Profile the template render stage
       | wp_footer:before         |
       | wp_footer                |
       | wp_footer:after          |
-      | total (13)               |
 
     When I run `wp profile stage template --fields=hook --orderby=hook --order=DESC`
     Then STDOUT should be a table containing rows:
@@ -81,8 +78,6 @@ Feature: Profile the template render stage
       | loop_start               |
       | loop_end:before          |
       | loop_end                 |
-      | total (13)               |
-
 
   Scenario: Use --all flag to profile all stages
     Given a WP install
@@ -142,7 +137,7 @@ Feature: Profile the template render stage
     When I run `wp profile stage bootstrap --fields=hook,callback_count`
     Then STDOUT should be a table containing rows:
       | hook              | callback_count   |
-      | plugins_loaded    | 3                |
+      | muplugins_loaded  | 2                |
 
   Scenario: Use spotlight mode to filter out the zero-ish values
     Given a WP install

--- a/features/profile.feature
+++ b/features/profile.feature
@@ -36,7 +36,7 @@ Feature: Basic profile usage
   Scenario: Profile a hook without any callbacks
     Given a WP install
 
-    When I run `wp profile hook setup_theme --fields=callback,time`
+    When I run `wp profile hook get_search_form --fields=callback,time`
     Then STDOUT should be a table containing rows:
       | callback          | time   |
       | total (0)         |        |
@@ -45,7 +45,7 @@ Feature: Basic profile usage
   Scenario: Trailingslash provided URL to avoid canonical redirect
     Given a WP install
 
-    When I run `wp profile hook setup_theme --url=example.com --fields=callback,time`
+    When I run `wp profile hook get_search_form --url=example.com --fields=callback,time`
     Then STDERR should be empty
     And STDOUT should be a table containing rows:
       | callback          | time   |

--- a/inc/class-formatter.php
+++ b/inc/class-formatter.php
@@ -42,7 +42,7 @@ class Formatter {
 	 *
 	 * @param array $items
 	 */
-	public function display_items( $items, $include_total = true, $order, $orderby ) {
+	public function display_items( $items, $include_total, $order, $orderby ) {
 		if ( 'table' === $this->args['format'] && empty( $this->args['field'] ) ) {
 			$this->show_table( $order, $orderby, $items, $this->args['fields'], $include_total );
 		} else {


### PR DESCRIPTION
This parameter isn't actually optional because it is followed by required parameters. This issues a warning on PHP 8.

```
Deprecated: Required parameter $order follows optional parameter $include_total in /Users/timothybjacobs/Workspace/wp-cli-dev/profile-command/inc/class-formatter.php on line 45
```