### PR TITLE
Fix newly reported PHPStan errors

### DIFF
--- a/src/Formatter.php
+++ b/src/Formatter.php
@@ -196,7 +196,13 @@ class Formatter {
 					$values[ $i ] = round( $value_num, 4 ) . 's';
 				}
 			}
-			$table->addRow( $values );
+			$row = array_map(
+				function ( $val ) {
+					return is_scalar( $val ) ? (string) $val : '';
+				},
+				$values
+			);
+			$table->addRow( $row );
 		}
 		if ( $include_total ) {
 			foreach ( $totals as $i => $value ) {
@@ -221,7 +227,13 @@ class Formatter {
 					}
 				}
 			}
-			$table->setFooters( $totals );
+			$footers = array_map(
+				function ( $val ) {
+					return is_scalar( $val ) ? (string) $val : '';
+				},
+				$totals
+			);
+			$table->setFooters( $footers );
 		}
 
 		foreach ( $table->getDisplayLines() as $line ) {

--- a/src/Profiler.php
+++ b/src/Profiler.php
@@ -632,7 +632,7 @@ class Profiler {
 			$name       = get_class( $callback[0] ) . '->' . $callback[1] . '()';
 		} elseif ( is_array( $callback ) && isset( $callback[0] ) && isset( $callback[1] ) && ( is_object( $callback[0] ) || is_string( $callback[0] ) ) && is_string( $callback[1] ) && method_exists( $callback[0], $callback[1] ) ) {
 			$reflection = new \ReflectionMethod( $callback[0], $callback[1] );
-			$class_name = $callback[0];
+			$class_name = is_object( $callback[0] ) ? get_class( $callback[0] ) : $callback[0];
 			$name       = $class_name . '::' . $callback[1] . '()';
 		} elseif ( is_object( $callback ) && is_a( $callback, 'Closure' ) ) {
 			$reflection = new \ReflectionFunction( $callback );


### PR DESCRIPTION
### Description
This PR resolves 3 static analysis errors reported by PHPStan:

1. **`src/Formatter.php`**: Ensures rows passed to `cli\Table::addRow()` and footers passed to `cli\Table::setFooters()` are properly typed as `array<int, string>` by casting scalar cell values to strings.
2. **`src/Profiler.php`**: Resolves object class names using `get_class()` before concatenating with `::` in `get_name_location_from_callback()` to prevent binary concatenation issues between objects and strings.

### Checks
- [x] `composer lint` passes
- [x] `composer phpcs` passes
- [x] `composer phpstan` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table rendering by safely displaying non-scalar cell and total values as blank entries.
  * Corrected profiler callback naming for callbacks associated with object instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->