### PR TITLE
Modernize deprecated syntax in Behat tests

### DIFF
--- a/features/profile.feature
+++ b/features/profile.feature
@@ -26,7 +26,7 @@ Feature: Basic profile usage
       """
       define( 'SAVEQUERIES', false );
       """
-    And I run `wp core config {CORE_CONFIG_SETTINGS} --skip-check --extra-php < extra-php`
+    And I run `wp config create {CORE_CONFIG_SETTINGS} --skip-check --extra-php < extra-php`
 
     When I run `wp core install --url='https://localhost' --title='Test' --admin_user=wpcli --admin_email=admin@example.com --admin_password=1`
     Then the return code should be 0


### PR DESCRIPTION
## What

Updates the Behat tests to use the current command syntax instead of forms deprecated by wp-cli/wp-cli#6356.

## Why

The framework now emits a deprecation warning to STDERR when it rewrites these legacy forms. This breaks `When I run` steps, which expect STDERR to remain empty.

## Tests

- `composer test`
